### PR TITLE
Removed "* Live migration is not supported."

### DIFF
--- a/limitations.md
+++ b/limitations.md
@@ -72,7 +72,6 @@ An {{site.data.keyword.vpc_short}} cannot be peered with other VPCs natively. It
 * Start/Stop actions are not registered under virtual server instance activity in the UI.
 * Activity Tracker logs (request logs and resource lifecycle event logs) are not available.
 * Updating the profile of a created instance is not supported.
-* Live migration is not supported.
 
 * We have temporarily suspended API support for creating new instances from an existing boot volume. For more information, see the [API change log](/docs/vpc?topic=vpc-api-change-log).
 


### PR DESCRIPTION
CFD-859. At the request of Alise Spence, removed the bullet point "Live migration is not supported." from the Compute limitations section.