### PR TITLE
ratio changed for memory family vCPU

### DIFF
--- a/vsi_is_profiles.md
+++ b/vsi_is_profiles.md
@@ -131,7 +131,7 @@ The following information describes the naming rule of the profiles.
 The first character represents the profile families. Different profile families have different ratios of CPU to memory, which is designed for different workloads.
 -	"b": balanced family, 1:4 ratio
 -	"c": compute family (higher on the CPUs), 1:2 ratio
--	"m": memory family (higher on the memory), 1:16 ratio
+-	"m": memory family (higher on the memory), 1:8 ratio
 
 The second character represents the CPU architecture.
 - "x": x86_64


### PR DESCRIPTION
Changed 
From:

-	"m": memory family (higher on the memory), 1:16 ratio

To
-	"m": memory family (higher on the memory), 1:8 ratio