### PR TITLE
Missing S2S authorizations prevent job creation

### DIFF
--- a/backup_service_vpc_troubleshoot.md
+++ b/backup_service_vpc_troubleshoot.md
@@ -32,6 +32,7 @@ Some causes might be:
 * Your volume might be deattached after the successful backups were made.
 * The volume tag that matched the tag for target resources might be deleted.
 * The instance might not be running.
+* Correct service-to-service authorizations may not be in place.
 
 Verify that the volume wasn't detached from a virtual server instance. Search for the instance to which you last attached the volume from the list of all virtual server instances. Verify that the instance is running. Also, look at the backup policy and verify that the tags are present in the volume, in case the tag was inadvertently deleted. Scheduled backups do not occur instantly, so you might need to look again in an hour or so to verify that the backup was made.
 {: tsResolve}


### PR DESCRIPTION
In my case, I was able to create policies without issue, but backup jobs were never being created due to a lack of S2S authorizations.  Added a bullet to this section mentioning this may be the case.