### PR TITLE
Fix wrongly referred ACL column name is the ACL rule creation workflow

### DIFF
--- a/acl-create.md
+++ b/acl-create.md
@@ -39,7 +39,7 @@ To configure an ACL in the {{site.data.keyword.cloud_notm}} console, follow thes
 
 1. Enter values for the following fields under details:
 
-   * **Public gateway name** - Type a unique name for your access control list.
+   * **Access control list name** - Type a unique name for your access control list.
    * **Resource group** -  Select a resource group for your access control list. You can use the default group for this access control list, or select from the resource group list (if defined). For more information, see [Best practices for organizing resources in a resource group](/docs/account?topic=account-account_setup).
 
    After provisioning is complete, you cannot change the resource group.
@@ -47,7 +47,7 @@ To configure an ACL in the {{site.data.keyword.cloud_notm}} console, follow thes
 
    * **Tags** - Add user tags. User tags are visible account-wide. For more information, see [Working with tags](/docs/account?topic=account-tag).
    * **Access management tags** - Add access management tags to help organize access control relationships. For more information, see [Controlling access to resources by using tags](/docs/account?topic=account-access-tags-tutorial).
-   * **VPC** - Select a VPC. You can use the default VPC for this public gateway, or select from the list (if defined). For more information, see [Getting started with Virtual Private Cloud](/docs/vpc?topic=vpc-getting-started&interface=ui).
+   * **VPC** - Select a VPC. You can use the default VPC for this access control list, or select from the list (if defined). For more information, see [Getting started with Virtual Private Cloud](/docs/vpc?topic=vpc-getting-started&interface=ui).
 
 1. Under Rules, click **Create +** to configure inbound and outbound rules that define what traffic is allowed in or out of the subnet. For each rule, specify the following information:
       * Select whether to allow or deny the specified traffic.


### PR DESCRIPTION
Thanks for taking the time to contribute to the IBM Cloud docs! After you open your pull request, a maintainer should review it soon.

We don't merge changes directly in this repository because content is not published from here. However, we'll incorporate any changes in our upstream repository so that they're reflected in the docs.

### Description

<!--- Replace this text with a summary of the changes in this pull request. Include why the changes are needed and context about the changes. --->

1. In the ACL create docs , name of ACL is referred as Public gateway name
2. n the ACL create docs , associating ACL with vpc is referred as associating with vpc with public gateway. 


###  Any other comments?

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/2c9a5403-50d3-4ffc-a041-fa6fe97ff49a" />
---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
